### PR TITLE
Upgrade project to AGP 8.0.0 - To support latest stable AS Flamingo

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,21 +1,22 @@
 name: CI
 on: [pull_request, push]
 jobs:
-  android-ci:
-    runs-on: macos-12
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
       - name: Set up JDK 17
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '17'
-
-      - name: Checkout the code
-      - uses: actions/checkout@v3
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
 
       - name: Build the app
         run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,11 +1,22 @@
 name: CI
 on: [pull_request, push]
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  android-ci:
+    runs-on: macos-12
+
     steps:
+      - name: Set up JDK 17
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
       - name: Checkout the code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
       - name: Build the app
         run: ./gradlew build
       - name: Unit tests

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdk rootProject.target_sdk_version
         versionCode 1
         versionName "1.0"
-        resConfigs 'en', 'ca', 'es'
+        resourceConfigurations += ['en', 'ca', 'es']
 
         testInstrumentationRunner "dev.guillem.githubbrowserlab.CustomTestRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,11 @@ android {
         testInstrumentationRunner "dev.guillem.githubbrowserlab.CustomTestRunner"
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.8.10"
+    ext.kotlin_version = "1.8.20"
     ext.hilt_version = '2.45'
     repositories {
         google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.defaults.buildfeatures.buildconfig=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip


### PR DESCRIPTION
Upgrade the AGP by running the AS upgrade assistant.

The upgrade consisted of the following steps:
Upgrade AGP dependency from 7.4.2 to 8.0.0
Upgrade Gradle version to 8.0
Update default R8 processing mode
Enable buildConfig build feature
Preserve transitive R classes
Preserve constant R class values

Optional changes:
Rewrite deprecated operators
Disable jetifier
Add compile options to Java 17
